### PR TITLE
Replace Copy with Clone for Matrix/Vector

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,4 @@ edition = "2018"
 crate_type = ["lib"]
 
 [dependencies]
-num = "0.4.0"
 num-traits = "0.2.14"
-nalgebra = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,8 @@
 //! };
 //!
 //! // Are the matrices invertible?
-//! assert_ne!(mat_a.det()?, 0_f64);
-//! assert_ne!(mat_b.det()?, 0_f64);
+//! assert_ne!(mat_a.det()?, 0);
+//! assert_ne!(mat_b.det()?, 0);
 //! # Ok(()) }
 //! ```
 //!

--- a/src/mat/_mat/mat_impl.rs
+++ b/src/mat/_mat/mat_impl.rs
@@ -2,7 +2,7 @@ use crate::err::DimensionError;
 use crate::mat::dims::Dimensions;
 use crate::mat::{Matrix, Vector};
 use num_traits::{sign, One, Zero};
-use std::{convert::From, fmt::Display};
+use std::convert::From;
 
 impl<T> Matrix<T>
 where
@@ -261,7 +261,7 @@ where
     /// ```
     pub fn det(&self) -> Result<T, DimensionError>
     where
-        T: sign::Signed + PartialOrd + Display + std::iter::Sum,
+        T: sign::Signed + PartialOrd + std::iter::Sum,
     {
         if let Some((mat, p)) = self.lupdecompose()? {
             let mut det = mat.matrix[0].clone();

--- a/src/mat/_mat/mat_impl.rs
+++ b/src/mat/_mat/mat_impl.rs
@@ -1,13 +1,12 @@
 use crate::err::DimensionError;
 use crate::mat::dims::Dimensions;
-use crate::mat::Matrix;
-use num_traits::identities::{One, Zero};
-use num_traits::{cast, sign};
-use std::fmt::Display;
+use crate::mat::{Matrix, Vector};
+use num_traits::{sign, One, Zero};
+use std::{convert::From, fmt::Display};
 
 impl<T> Matrix<T>
 where
-    T: Copy,
+    T: Clone + One + Zero,
 {
     /// Create a new matrix of type `T` with `init` as the default value for each entry.
     ///
@@ -114,10 +113,7 @@ where
     /// // 0 0 1
     /// # Ok(()) }
     /// ```
-    pub fn one(dim: usize) -> Result<Matrix<T>, DimensionError>
-    where
-        T: One + Zero,
-    {
+    pub fn one(dim: usize) -> Result<Matrix<T>, DimensionError> {
         let mut res = Matrix::<T>::zero(dim, dim)?;
         for i in 0..dim {
             res[i][i] = T::one();
@@ -142,11 +138,8 @@ where
     /// assert_eq!(mat, Matrix::new(3, 8, 0)?);
     /// # Ok(()) }
     /// ```
-    pub fn zero(rows: usize, cols: usize) -> Result<Matrix<T>, DimensionError>
-    where
-        T: Zero,
-    {
-        Ok(Self::new(rows, cols, T::zero())?)
+    pub fn zero(rows: usize, cols: usize) -> Result<Matrix<T>, DimensionError> {
+        Self::new(rows, cols, T::zero())
     }
 
     /// Create a diagonal matrix of type `T` with entries `init`.
@@ -166,43 +159,40 @@ where
     /// assert_eq!(mat, Matrix::one(3)?);
     /// # Ok(()) }
     /// ```
-    pub fn diag(dim: usize, init: T) -> Result<Matrix<T>, DimensionError>
-    where
-        T: Zero + One,
-    {
-        Ok(Matrix::<T>::one(dim)? * init)
+    pub fn diag(dim: usize, init: T) -> Result<Matrix<T>, DimensionError> {
+        let mut res = Matrix::<T>::zero(dim, dim)?;
+        for i in 0..dim {
+            res[i][i] = init.clone();
+        }
+        Ok(res)
     }
 
     /// Creates a diagonal matrix with dimensions `dim x dim` and initial entries specified in `entries`.
-    pub fn diag_with(dim: usize, entries: &[T]) -> Result<Matrix<T>, DimensionError>
-    where
-        T: Zero + One,
-    {
-        if entries.len() > dim || entries.len() < dim {
-            panic!("Input slice does not have the correct length.");
+    pub fn diag_with(dim: usize, entries: &[T]) -> Result<Matrix<T>, DimensionError> {
+        if entries.len() != dim {
+            return Err(DimensionError::InvalidInputDimensions(entries.len(), dim));
         }
         let mut res_mat = Matrix::one(dim)?;
         for i in 0..dim {
-            res_mat[i][i] = entries[i];
+            res_mat[i][i] = entries[i].clone();
         }
         Ok(res_mat)
     }
-    pub fn lupdecompose(&self) -> Result<Option<(Matrix<f64>, Vec<usize>)>, DimensionError>
+    pub fn lupdecompose(&self) -> Result<Option<(Matrix<T>, Vec<usize>)>, DimensionError>
     where
-        T: sign::Signed + PartialOrd + cast::ToPrimitive,
+        T: sign::Signed + PartialOrd + Clone + Zero + One + std::iter::Sum,
     {
         if !self.is_square() {
             Err(DimensionError::NoSquare)
         } else {
-            let mut a = Matrix::zero(self.dims.get_rows(), self.dims.get_cols()).unwrap();
-            a.matrix = self.matrix.iter().map(|&x| x.to_f64().unwrap()).collect();
+            let mut a: Matrix<T> = self.clone();
             let dim = self.dims.get_rows();
             let mut imax: usize;
-            let mut max_a: f64;
+            let mut max_a: T;
             let mut p: Vec<usize> = (0..=dim).collect();
 
             for i in 0..dim {
-                max_a = 0_f64;
+                max_a = T::zero();
                 imax = i;
 
                 for k in i..dim {
@@ -216,37 +206,35 @@ where
                     }
                 }
 
-                if max_a < 0.000001 {
+                if max_a.is_zero() {
                     return Ok(None);
                 }
 
                 if imax != i {
-                    let j = p[i];
-                    p[i] = p[imax];
-                    p[imax] = j;
+                    p.swap(i, imax);
 
-                    let mut t_ij: Matrix<f64> = Matrix::one(self.dims.get_rows()).unwrap();
+                    let mut t_ij: Matrix<T> = Matrix::one(self.dims.get_rows()).unwrap();
                     // t_ij.matrix[i * dim + i] = 0_f64;
                     // t_ij.matrix[imax * dim + imax] = 0_f64;
                     // t_ij.matrix[i * dim + imax] = 1_f64;
                     // t_ij.matrix[imax * dim + i] = 1_f64;
-                    t_ij[i][i] = 0_f64;
-                    t_ij[imax][imax] = 0_f64;
-                    t_ij[i][imax] = 1_f64;
-                    t_ij[imax][i] = 1_f64;
+                    t_ij[i][i] = T::zero();
+                    t_ij[imax][imax] = T::zero();
+                    t_ij[i][imax] = T::one();
+                    t_ij[imax][i] = T::one();
                     // switch rows i and imax
-                    a = (a * t_ij).unwrap();
+                    a = (a * t_ij)?;
 
                     p[dim] += 1;
                 }
 
                 for j in (i + 1)..dim {
                     // a.matrix[j * dim + i] = a.matrix[j * dim + i] / a.matrix[i * dim + i];
-                    a[j][i] = a[j][i] / a[i][i];
+                    a[j][i] = a[j][i].clone() / a[i][i].clone();
                     for k in (i + 1)..dim {
                         // a.matrix[j * dim + k] =
                         //     a.matrix[j * dim + k] - (a.matrix[j * dim + i] * a.matrix[i * dim + k])
-                        a[j][k] = a[j][k] - a[j][i] * a[i][k];
+                        a[j][k] = a[j][k].clone() - a[j][i].clone() * a[i][k].clone();
                     }
                 }
             }
@@ -267,18 +255,18 @@ where
     /// # use libmat::matrix;
     /// # use libmat::err::DimensionError;
     /// # fn main() -> Result<(), DimensionError> {
-    /// let mat = matrix!{1, 2, 3; 3, 2, 1; 2, 1, 3};
+    /// let mat = matrix!{1.0, 2.0, 3.0; 3.0, 2.0, 1.0; 2.0, 1.0, 3.0};
     /// assert_eq!(mat.det()?, -12.0);
     /// # Ok(()) }
     /// ```
-    pub fn det(&self) -> Result<f64, DimensionError>
+    pub fn det(&self) -> Result<T, DimensionError>
     where
-        T: sign::Signed + PartialOrd + Display + cast::ToPrimitive,
+        T: sign::Signed + PartialOrd + Display + std::iter::Sum,
     {
         if let Some((mat, p)) = self.lupdecompose()? {
-            let mut det = mat.matrix[0];
+            let mut det = mat.matrix[0].clone();
             for i in 1..mat.col_count() {
-                det = det * mat.matrix[i * mat.col_count() + i];
+                det = det * mat.matrix[i * mat.col_count() + i].clone();
             }
             if (p[mat.row_count()] - mat.row_count()) % 2 == 0 {
                 Ok(det)
@@ -286,7 +274,7 @@ where
                 Ok(-det)
             }
         } else {
-            Ok(0_f64)
+            Ok(T::zero())
         }
     }
 
@@ -330,15 +318,27 @@ where
         let mut vec = Vec::<T>::new();
         for i in 0..self.dims.get_cols() {
             for j in 0..self.dims.get_rows() {
-                vec.push(self.matrix[j * self.dims.get_cols() + i]);
+                vec.push(self.matrix[j * self.dims.get_cols() + i].clone());
             }
         }
         Matrix::<T>::from_vec(self.dims.get_cols(), self.dims.get_rows(), vec).unwrap()
     }
 }
 
+impl<T> From<Vector<T>> for Matrix<T>
+where
+    T: Zero + One + Clone,
+{
+    fn from(v: Vector<T>) -> Matrix<T> {
+        Matrix::<T>::from_vec(v.dims.get_rows(), v.dims.get_cols(), v.entries).unwrap()
+    }
+}
+
 // GETTERS
-impl<T> Matrix<T> {
+impl<T> Matrix<T>
+where
+    T: Clone,
+{
     /// Get the number of rows
     pub fn row_count(&self) -> usize {
         self.dims.get_rows()

--- a/src/mat/_mat/mat_ops.rs
+++ b/src/mat/_mat/mat_ops.rs
@@ -65,7 +65,7 @@ use std::result::Result;
 /// ```
 impl<T> Add for Matrix<T>
 where
-    T: AddAssign + Zero + One + Clone,
+    T: AddAssign + Clone,
 {
     type Output = Result<Matrix<T>, DimensionError>;
 
@@ -86,7 +86,7 @@ where
 
 impl<T> AddAssign<Matrix<T>> for Matrix<T>
 where
-    T: AddAssign + Zero + One + Clone,
+    T: AddAssign + Clone,
 {
     fn add_assign(&mut self, rhs: Matrix<T>) {
         if self.dims != rhs.dims {
@@ -113,7 +113,7 @@ where
 /// ```
 impl<T> Add<T> for Matrix<T>
 where
-    T: AddAssign + Zero + One + Clone,
+    T: AddAssign + Clone,
 {
     type Output = Matrix<T>;
 
@@ -126,7 +126,7 @@ where
 
 impl<T> AddAssign<T> for Matrix<T>
 where
-    T: AddAssign + Zero + One + Clone,
+    T: AddAssign + Clone,
 {
     fn add_assign(&mut self, rhs: T) {
         self.matrix
@@ -150,7 +150,7 @@ where
 /// ```
 impl<T> Sub for Matrix<T>
 where
-    T: SubAssign + One + Zero + Clone,
+    T: SubAssign + Clone,
 {
     type Output = Result<Matrix<T>, DimensionError>;
 
@@ -171,7 +171,7 @@ where
 
 impl<T> SubAssign<Matrix<T>> for Matrix<T>
 where
-    T: SubAssign + Zero + One + Clone,
+    T: SubAssign + Clone,
 {
     fn sub_assign(&mut self, rhs: Matrix<T>) {
         if self.dims != rhs.dims {
@@ -233,7 +233,7 @@ where
 /// ```
 impl<T> Neg for Matrix<T>
 where
-    T: Neg<Output = T> + One + Zero + Clone,
+    T: Neg<Output = T> + Clone,
 {
     type Output = Matrix<T>;
 

--- a/src/mat/_mat/mat_ops.rs
+++ b/src/mat/_mat/mat_ops.rs
@@ -99,6 +99,42 @@ where
     }
 }
 
+/// Scalar addition.
+///
+/// # Example
+/// ```
+/// # use libmat::{err::DimensionError, matrix, mat::Matrix};
+/// # fn main() -> Result<(), DimensionError> {
+/// let mat_a = Matrix::one(3)?;
+/// let b = 3;
+/// let mat_c = matrix!{4, 3, 3; 3, 4, 3; 3, 3, 4};
+/// assert_eq!((mat_a + b), mat_c);
+/// # Ok(()) }
+/// ```
+impl<T> Add<T> for Matrix<T>
+where
+    T: AddAssign + Zero + One + Clone,
+{
+    type Output = Matrix<T>;
+
+    fn add(self, rhs: T) -> Self::Output {
+        let mut result_matrix = self;
+        result_matrix += rhs;
+        result_matrix
+    }
+}
+
+impl<T> AddAssign<T> for Matrix<T>
+where
+    T: AddAssign + Zero + One + Clone,
+{
+    fn add_assign(&mut self, rhs: T) {
+        self.matrix
+            .iter_mut()
+            .for_each(|a| *a += rhs.clone());
+    }
+}
+
 /// Elementwise subtraction. Both matrices need to have the same dimensions.
 ///
 /// # Example
@@ -145,6 +181,42 @@ where
             .iter_mut()
             .zip(rhs.matrix.iter())
             .for_each(|(a, b)| *a -= b.clone());
+    }
+}
+
+/// Scalar subtraction.
+///
+/// # Example
+/// ```
+/// # use libmat::{err::DimensionError, matrix, mat::Matrix};
+/// # fn main() -> Result<(), DimensionError> {
+/// let mat_a = Matrix::one(3)?;
+/// let b = 3;
+/// let mat_c = matrix!{-2, -3, -3; -3, -2, -3; -3, -3, -2};
+/// assert_eq!((mat_a - b), mat_c);
+/// # Ok(()) }
+/// ```
+impl<T> Sub<T> for Matrix<T>
+where
+    T: SubAssign + Clone,
+{
+    type Output = Matrix<T>;
+
+    fn sub(self, rhs: T) -> Self::Output {
+        let mut result = self;
+        result -= rhs;
+        result
+    }
+}
+
+impl<T> SubAssign<T> for Matrix<T>
+where
+    T: SubAssign + Clone,
+{
+    fn sub_assign(&mut self, rhs: T) {
+        self.matrix
+            .iter_mut()
+            .for_each(|a| *a -= rhs.clone());
     }
 }
 

--- a/src/mat/_mat/mat_ops.rs
+++ b/src/mat/_mat/mat_ops.rs
@@ -57,8 +57,8 @@ use std::result::Result;
 /// # use libmat::mat::Matrix;
 /// # use libmat::err::DimensionError;
 /// # fn main() -> Result<(), DimensionError> {
-/// let mat_a = Matrix::one(3)?;
-/// let mat_b = Matrix::one(3)?;
+/// let mat_a = Matrix::<i32>::one(3)?;
+/// let mat_b = Matrix::<i32>::one(3)?;
 /// let mat_c = Matrix::diag(3, 2)?;
 /// assert_eq!((mat_a + mat_b)?, mat_c);
 /// # Ok(()) }

--- a/src/mat/_mat/mat_ops.rs
+++ b/src/mat/_mat/mat_ops.rs
@@ -65,7 +65,7 @@ use std::result::Result;
 /// ```
 impl<T> Add for Matrix<T>
 where
-    T: Add<Output = T> + Zero + One + Clone + Copy,
+    T: AddAssign + Zero + One + Clone,
 {
     type Output = Result<Matrix<T>, DimensionError>;
 
@@ -77,7 +77,7 @@ where
                 "add".to_owned(),
             ))
         } else {
-            let mut result_matrix = self.clone();
+            let mut result_matrix = self;
             result_matrix += rhs;
             Ok(result_matrix)
         }
@@ -86,7 +86,7 @@ where
 
 impl<T> AddAssign<Matrix<T>> for Matrix<T>
 where
-    T: Sized + Add<Output = T> + Zero + One + Clone + Copy,
+    T: AddAssign + Zero + One + Clone,
 {
     fn add_assign(&mut self, rhs: Matrix<T>) {
         if self.dims != rhs.dims {
@@ -95,7 +95,7 @@ where
         self.matrix
             .iter_mut()
             .zip(rhs.matrix.iter())
-            .for_each(|(a, b)| *a = *a + *b);
+            .for_each(|(a, b)| *a += b.clone());
     }
 }
 
@@ -114,7 +114,7 @@ where
 /// ```
 impl<T> Sub for Matrix<T>
 where
-    T: Sub<Output = T> + One + Zero + Clone + Copy,
+    T: SubAssign + One + Zero + Clone,
 {
     type Output = Result<Matrix<T>, DimensionError>;
 
@@ -126,7 +126,7 @@ where
                 "add".to_owned(),
             ))
         } else {
-            let mut result_matrix = self.clone();
+            let mut result_matrix = self;
             result_matrix -= rhs;
             Ok(result_matrix)
         }
@@ -135,7 +135,7 @@ where
 
 impl<T> SubAssign<Matrix<T>> for Matrix<T>
 where
-    T: Sub<Output = T> + Zero + One + Copy + Clone,
+    T: SubAssign + Zero + One + Clone,
 {
     fn sub_assign(&mut self, rhs: Matrix<T>) {
         if self.dims != rhs.dims {
@@ -144,7 +144,7 @@ where
         self.matrix
             .iter_mut()
             .zip(rhs.matrix.iter())
-            .for_each(|(a, b)| *a = *a - *b);
+            .for_each(|(a, b)| *a -= b.clone());
     }
 }
 
@@ -161,13 +161,16 @@ where
 /// ```
 impl<T> Neg for Matrix<T>
 where
-    T: Neg<Output = T> + One + Zero + Copy,
+    T: Neg<Output = T> + One + Zero + Clone,
 {
     type Output = Matrix<T>;
 
     fn neg(self) -> Self::Output {
-        let mut result_matrix = self.clone();
-        result_matrix.matrix.iter_mut().for_each(|x| *x = -(*x));
+        let mut result_matrix = self;
+        result_matrix
+            .matrix
+            .iter_mut()
+            .for_each(|x| *x = -(x.clone()));
         result_matrix
     }
 }
@@ -191,7 +194,7 @@ where
 /// ```
 impl<T> Mul for Matrix<T>
 where
-    T: Zero + One + Copy + std::iter::Sum,
+    T: Zero + One + Clone + std::iter::Sum,
 {
     type Output = Result<Matrix<T>, DimensionError>;
 
@@ -240,7 +243,7 @@ where
                             *entry_mut = row_self
                                 .iter()
                                 .zip(col_rhs.iter())
-                                .map(|(a, b)| *a * *b)
+                                .map(|(a, b)| a.clone() * b.clone())
                                 .sum();
                         })
                 });
@@ -268,7 +271,7 @@ where
 /// ```
 impl<T> Mul<Vector<T>> for Matrix<T>
 where
-    T: One + Zero + Copy + std::iter::Sum,
+    T: One + Zero + std::iter::Sum + Clone,
 {
     type Output = Result<Vector<T>, DimensionError>;
 
@@ -292,12 +295,12 @@ where
 /// ```
 impl<T> Mul<T> for Matrix<T>
 where
-    T: Mul<Output = T> + Copy,
+    T: MulAssign + Clone,
 {
     type Output = Matrix<T>;
 
     fn mul(self, scalar: T) -> Self::Output {
-        let mut result_matrix = self.clone();
+        let mut result_matrix = self;
         result_matrix *= scalar;
         result_matrix
     }
@@ -305,10 +308,10 @@ where
 
 impl<T> MulAssign<T> for Matrix<T>
 where
-    T: Mul<Output = T> + Copy,
+    T: MulAssign + Clone,
 {
     fn mul_assign(&mut self, scalar: T) {
-        self.matrix.iter_mut().for_each(|a| *a = *a * scalar);
+        self.matrix.iter_mut().for_each(|a| *a *= scalar.clone());
     }
 }
 
@@ -326,12 +329,12 @@ where
 /// ```
 impl<T> Div<T> for Matrix<T>
 where
-    T: Div<Output = T> + Zero + PartialEq + Copy,
+    T: DivAssign + Zero + PartialEq + Clone,
 {
     type Output = Matrix<T>;
 
     fn div(self, divisor: T) -> Self::Output {
-        let mut result_matrix = self.clone();
+        let mut result_matrix = self;
         result_matrix /= divisor;
         result_matrix
     }
@@ -339,10 +342,10 @@ where
 
 impl<T> DivAssign<T> for Matrix<T>
 where
-    T: Div<Output = T> + Copy,
+    T: DivAssign + Clone,
 {
     fn div_assign(&mut self, divisor: T) {
-        self.matrix.iter_mut().for_each(|a| *a = *a / divisor)
+        self.matrix.iter_mut().for_each(|a| *a /= divisor.clone())
     }
 }
 

--- a/src/mat/smat/smat_impl.rs
+++ b/src/mat/smat/smat_impl.rs
@@ -113,9 +113,7 @@ where
             }
 
             if imax != i {
-                let j = p[i];
-                p[i] = p[imax];
-                p[imax] = j;
+                p.swap(i, imax);
 
                 let mut t_ij: SMatrix<f64, N, N> = SMatrix::one();
                 t_ij[i][i] = f64::zero();
@@ -129,9 +127,9 @@ where
             }
 
             for j in (i + 1)..dim {
-                a[j][i] = a[j][i] / a[i][i];
+                a[j][i] /= a[i][i];
                 for k in (i + 1)..dim {
-                    a[j][k] = a[j][k] - a[j][i] * a[i][k];
+                    a[j][k] -= a[j][i] * a[i][k];
                 }
             }
         }
@@ -144,7 +142,7 @@ where
         if let Some((mat, p)) = self.lupdecompose() {
             let mut det = mat[0][0];
             for i in 1..N {
-                det = det * mat[i][i];
+                det *= mat[i][i];
             }
             if (p[N] - N) % 2 == 0 {
                 det

--- a/src/mat/smat/smat_ops.rs
+++ b/src/mat/smat/smat_ops.rs
@@ -52,7 +52,7 @@ where
     type Output = SMatrix<T, M, N>;
 
     fn add(self, rhs: SMatrix<T, M, N>) -> Self::Output {
-        let mut result = self.clone();
+        let mut result = self;
         result += rhs;
         result
     }
@@ -78,7 +78,7 @@ where
     type Output = SMatrix<T, M, N>;
 
     fn sub(self, rhs: SMatrix<T, M, N>) -> Self::Output {
-        let mut result = self.clone();
+        let mut result = self;
         result -= rhs;
         result
     }
@@ -134,7 +134,7 @@ where
     type Output = SMatrix<T, M, N>;
 
     fn mul(self, rhs: T) -> Self::Output {
-        let mut result = self.clone();
+        let mut result = self;
         result *= rhs;
         result
     }
@@ -156,7 +156,7 @@ where
 {
     type Output = Self;
     fn div(self, rhs: T) -> Self::Output {
-        let mut result = self.clone();
+        let mut result = self;
         result /= rhs;
         result
     }

--- a/src/mat/smat/smat_traits.rs
+++ b/src/mat/smat/smat_traits.rs
@@ -21,7 +21,7 @@ where
                 } else if es.peek().is_some() {
                     write!(f, "\t")?;
                 } else {
-                    write!(f, "\n")?;
+                    writeln!(f)?;
                 }
             }
         }
@@ -93,15 +93,15 @@ where
                     };
 
                     for k in 0..i {
-                        mat_inv[i][j] = mat_inv[i][j] - mat[i][k] * mat_inv[k][j];
+                        mat_inv[i][j] -= mat[i][k] * mat_inv[k][j];
                     }
                 }
 
                 for i in (0..=(dim - 1)).rev() {
                     for k in (i + 1)..dim {
-                        mat_inv[i][j] = mat_inv[i][j] - mat[i][k] * mat_inv[k][j];
+                        mat_inv[i][j] -= mat[i][k] * mat_inv[k][j];
                     }
-                    mat_inv[i][j] = mat_inv[i][j] / mat[i][i];
+                    mat_inv[i][j] /= mat[i][i];
                 }
             }
             Some(mat_inv)

--- a/src/mat/vec/vec_impl.rs
+++ b/src/mat/vec/vec_impl.rs
@@ -1,7 +1,6 @@
 use crate::mat::dims::Dimensions;
 use crate::mat::{Matrix, Vector};
-use num_traits::identities::{One, Zero};
-use std::convert::{From, Into};
+use std::convert::From;
 
 impl<T> Vector<T>
 where
@@ -41,15 +40,6 @@ where
     }
 }
 
-impl<T> Into<Matrix<T>> for Vector<T>
-where
-    T: Zero + One + Copy,
-{
-    fn into(self) -> Matrix<T> {
-        Matrix::<T>::from_vec(self.dims.get_rows(), self.dims.get_cols(), self.entries).unwrap()
-    }
-}
-
 impl<T> From<Vec<T>> for Vector<T>
 where
     T: Clone,
@@ -62,7 +52,10 @@ where
     }
 }
 
-impl<T> From<Matrix<T>> for Vector<T> {
+impl<T> From<Matrix<T>> for Vector<T>
+where
+    T: Clone,
+{
     fn from(mat: Matrix<T>) -> Vector<T> {
         if mat.row_count() != 1 && mat.col_count() != 1 {
             panic!("Could not convert matrix into vector.");

--- a/src/mat/vec/vec_ops.rs
+++ b/src/mat/vec/vec_ops.rs
@@ -1,6 +1,6 @@
 use crate::err::DimensionError;
 use crate::mat::{Matrix, Vector};
-use num_traits::identities::{One, Zero};
+use num_traits::{One, Zero};
 use std::fmt::Display;
 use std::ops::{
     Add, AddAssign, Deref, DerefMut, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign,
@@ -22,7 +22,7 @@ use std::ops::{
 /// ```
 impl<T> Add for Vector<T>
 where
-    T: Add<Output = T> + Clone + Copy,
+    T: AddAssign + Clone,
 {
     type Output = Result<Vector<T>, DimensionError>;
 
@@ -34,7 +34,7 @@ where
                 "add".to_owned(),
             ))
         } else {
-            let mut result_vector = self.clone();
+            let mut result_vector = self;
             result_vector += vector;
             Ok(result_vector)
         }
@@ -43,7 +43,7 @@ where
 
 impl<T> AddAssign<Vector<T>> for Vector<T>
 where
-    T: Add<Output = T> + Clone + Copy,
+    T: AddAssign + Clone,
 {
     fn add_assign(&mut self, vector: Vector<T>) {
         if self.len() != vector.len() {
@@ -51,7 +51,7 @@ where
         }
         self.iter_mut()
             .zip(vector.iter())
-            .for_each(|(a, b)| *a = *a + *b);
+            .for_each(|(a, b)| *a += b.clone());
     }
 }
 
@@ -71,7 +71,7 @@ where
 /// ```
 impl<T> Sub for Vector<T>
 where
-    T: Sub<Output = T> + Zero + One + Copy + Clone,
+    T: SubAssign + Zero + One + Clone,
 {
     type Output = Result<Vector<T>, DimensionError>;
 
@@ -83,7 +83,7 @@ where
                 "subtract".to_owned(),
             ))
         } else {
-            let mut result_vector = self.clone();
+            let mut result_vector = self;
             result_vector -= vector;
             Ok(result_vector)
         }
@@ -92,7 +92,7 @@ where
 
 impl<T> SubAssign<Vector<T>> for Vector<T>
 where
-    T: Sub<Output = T> + Zero + One + Copy + Clone,
+    T: SubAssign + Zero + One + Clone,
 {
     fn sub_assign(&mut self, vector: Vector<T>) {
         if self.len() != vector.len() {
@@ -100,19 +100,19 @@ where
         }
         self.iter_mut()
             .zip(vector.iter())
-            .for_each(|(a, b)| *a = *a - *b);
+            .for_each(|(a, b)| *a -= b.clone());
     }
 }
 
 impl<T> Neg for Vector<T>
 where
-    T: Neg<Output = T> + One + Zero + Copy,
+    T: Neg<Output = T> + One + Zero + Clone,
 {
     type Output = Vector<T>;
 
     fn neg(self) -> Self::Output {
-        let mut result_vector = self.clone();
-        result_vector.iter_mut().for_each(|a| *a = -(*a));
+        let mut result_vector = self;
+        result_vector.iter_mut().for_each(|a| *a = -(a.clone()));
         result_vector
     }
 }
@@ -134,7 +134,7 @@ where
 /// ```
 impl<T> Mul for Vector<T>
 where
-    T: Mul<Output = T> + Copy + Zero + std::iter::Sum,
+    T: Mul<Output = T> + Clone + Zero + std::iter::Sum,
 {
     type Output = Result<T, DimensionError>;
 
@@ -146,7 +146,11 @@ where
                 "multiply".to_owned(),
             ))
         } else {
-            let sum = self.iter().zip(vector.iter()).map(|(a, b)| *a * *b).sum();
+            let sum = self
+                .iter()
+                .zip(vector.iter())
+                .map(|(a, b)| a.clone() * b.clone())
+                .sum();
             Ok(sum)
         }
     }
@@ -171,13 +175,13 @@ where
 /// ```
 impl<T> Mul<Matrix<T>> for Vector<T>
 where
-    T: One + Zero + Clone + Copy + std::iter::Sum + Display,
+    T: One + Zero + Clone + std::iter::Sum + Display,
     Vector<T>: Into<Matrix<T>>,
 {
     type Output = Result<Vector<T>, DimensionError>;
 
     fn mul(self, mat: Matrix<T>) -> Self::Output {
-        let vector: Vector<T> = self.clone();
+        let vector: Vector<T> = self;
         let mat_v: Matrix<T> = vector.into();
         println!("{}\n\n{}", mat_v, mat);
         let res = (mat_v * mat)?;
@@ -197,12 +201,12 @@ where
 /// ```
 impl<T> Mul<T> for Vector<T>
 where
-    T: Mul<Output = T> + Copy,
+    T: MulAssign + Clone,
 {
     type Output = Vector<T>;
 
     fn mul(self, rhs: T) -> Self::Output {
-        let mut result_vector = self.clone();
+        let mut result_vector = self;
         result_vector *= rhs;
         result_vector
     }
@@ -210,10 +214,10 @@ where
 
 impl<T> MulAssign<T> for Vector<T>
 where
-    T: Mul<Output = T> + Copy,
+    T: MulAssign + Clone,
 {
     fn mul_assign(&mut self, rhs: T) {
-        self.iter_mut().for_each(|a| *a = *a * rhs);
+        self.iter_mut().for_each(|a| *a *= rhs.clone());
     }
 }
 
@@ -228,12 +232,12 @@ where
 /// ```
 impl<T> Div<T> for Vector<T>
 where
-    T: Div<Output = T> + Copy,
+    T: DivAssign + Clone,
 {
     type Output = Vector<T>;
 
     fn div(self, divisor: T) -> Self::Output {
-        let mut result_matrix = self.clone();
+        let mut result_matrix = self;
         result_matrix /= divisor;
         result_matrix
     }
@@ -241,10 +245,10 @@ where
 
 impl<T> DivAssign<T> for Vector<T>
 where
-    T: Div<Output = T> + Copy,
+    T: DivAssign + Clone,
 {
     fn div_assign(&mut self, rhs: T) {
-        self.iter_mut().for_each(|a| *a = *a / rhs)
+        self.iter_mut().for_each(|a| *a /= rhs.clone())
     }
 }
 

--- a/src/mat/vec/vec_ops.rs
+++ b/src/mat/vec/vec_ops.rs
@@ -55,6 +55,42 @@ where
     }
 }
 
+/// Scalar addition.
+///
+/// # Example
+/// ```
+/// # use libmat::mat::Vector;
+/// # use libmat::vector;
+/// # fn main() {
+/// let vec_a = vector![1_i32, 2, 3];
+/// let b = 3;
+/// let vec_c = vector![4_i32, 5, 6];
+/// assert_eq!((vec_a + b), vec_c);
+/// # }
+/// ```
+impl<T> Add<T> for Vector<T>
+where
+    T: AddAssign + Clone,
+{
+    type Output = Vector<T>;
+
+    fn add(self, rhs: T) -> Self::Output {
+        let mut result = self;
+        result += rhs;
+        result
+    }
+}
+
+impl<T> AddAssign<T> for Vector<T>
+where
+    T: AddAssign + Clone,
+{
+    fn add_assign(&mut self, rhs: T) {
+        self.iter_mut()
+            .for_each(|a| *a += rhs.clone());
+    }
+}
+
 /// Elementwise subtraction. Both vectors need to have the same length.
 ///
 /// # Example
@@ -101,6 +137,42 @@ where
         self.iter_mut()
             .zip(vector.iter())
             .for_each(|(a, b)| *a -= b.clone());
+    }
+}
+
+/// Scalar subtraction.
+///
+/// # Example
+/// ```
+/// # use libmat::mat::Vector;
+/// # use libmat::vector;
+/// # fn main() {
+/// let vec_a = vector![4_i32, 5, 6];
+/// let b = 3;
+/// let vec_c = vector![1_i32, 2, 3];
+/// assert_eq!((vec_a - b), vec_c);
+/// # }
+/// ```
+impl<T> Sub<T> for Vector<T>
+where
+    T: SubAssign + Clone,
+{
+    type Output = Vector<T>;
+
+    fn sub(self, rhs: T) -> Self::Output {
+        let mut result = self;
+        result -= rhs;
+        result
+    }
+}
+
+impl<T> SubAssign<T> for Vector<T>
+where
+    T: SubAssign + Clone,
+{
+    fn sub_assign(&mut self, rhs: T) {
+        self.iter_mut()
+            .for_each(|a| *a -= rhs.clone());
     }
 }
 

--- a/tests/determinant.rs
+++ b/tests/determinant.rs
@@ -10,32 +10,32 @@ fn not_square() -> Result<(), DimensionError> {
 #[test]
 fn id_mat() -> Result<(), DimensionError> {
     let a: Matrix<f32> = Matrix::one(3)?;
-    assert_eq!(a.det()?, 1_f64);
+    assert_eq!(a.det()?, 1_f32);
     let b: Matrix<f32> = Matrix::one(100)?;
-    assert_eq!(b.det()?, 1_f64);
+    assert_eq!(b.det()?, 1_f32);
     Ok(())
 }
 
 #[test]
 fn null_mat() -> Result<(), DimensionError> {
     let a: Matrix<i32> = Matrix::zero(3, 3)?;
-    assert_eq!(a.det()?, 0_f64);
+    assert_eq!(a.det()?, 0);
     Ok(())
 }
 
 #[test]
 fn some_dets() -> Result<(), DimensionError> {
-    let a = Matrix::from_vec(3, 3, vec![1, 2, 3, 3, 2, 1, 2, 1, 3])?;
-    assert_eq!(a.det()?, -12_f64);
-    let b = Matrix::from_vec(
+    let a = Matrix::<f32>::from_vec(3, 3, vec![1.0, 2.0, 3.0, 3.0, 2.0, 1.0, 2.0, 1.0, 3.0])?;
+    assert_eq!(a.det()?, -12_f32);
+    let b = Matrix::<f32>::from_vec(
         8,
         8,
         vec![
             8, 6, 1, 0, 1, 9, 5, 9, 9, 9, 0, 8, 4, 3, 4, 0, 5, 6, 5, 1, 0, 9, 4, 6, 4, 9, 8, 3, 5,
             1, 10, 6, 3, 10, 7, 4, 9, 2, 0, 1, 2, 1, 6, 8, 7, 3, 2, 9, 1, 7, 1, 4, 4, 9, 0, 0, 7,
             6, 4, 0, 10, 4, 5, 9,
-        ],
+        ].iter().map(|x| (*x as i16).into()).collect(),
     )?;
-    assert_eq!(b.det()?.round(), -15546220_f64);
+    assert_eq!(b.det()?, -15546220_f32);
     Ok(())
 }


### PR DESCRIPTION
This removes the Copy trait for vectors and replaces it with Clone trait.
Substitutes *Assign version of operators to reduce number of clones.
  e.g. *a *= b.clone in place of *a = a.clone() * b.clone()
Have determinate return T
Update tests/examples to handle T being returned from Matrix::det().
Fix most clippy warnings.
Remove unused dependencies.

Signed-off-by: Nathaniel Clark <Nathaniel.Clark@misrule.us>